### PR TITLE
Updates to latest fastlane, Danger and travis-ci Xcode image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode10
+osx_image: xcode10.1
 
 cache:
   bundler: true

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
-gem 'danger', '~> 5.6'
-gem 'fastlane', '~> 2.102'
+gem 'danger', '~> 5.7.1'
+gem 'fastlane', '~> 2.107.0'
 gem 'travis', '~> 1.8'
 gem 'openssl', '~> 2.1'
 gem "pry"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -210,11 +210,11 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  danger (~> 5.6)
-  fastlane (~> 2.102)
+  danger (~> 5.7.1)
+  fastlane (~> 2.107.0)
   openssl (~> 2.1)
   pry
   travis (~> 1.8)
 
 BUNDLED WITH
-   1.16.4
+   1.17.1

--- a/Makefile
+++ b/Makefile
@@ -52,9 +52,9 @@ install_bundler_gem:
 	$(info Checking and install bundler ...)
 
 ifeq ($(BUNDLER),)
-	gem install bundler -v '~> 1.16'
+	gem install bundler -v '~> 1.17'
 else
-	gem update bundler '~> 1.16'
+	gem update bundler '~> 1.17'
 endif
 
 install_ruby_gems:


### PR DESCRIPTION
Updates the project template dependencies versions:

- fastlane: 2.107.0 (https://github.com/fastlane/fastlane/releases/tag/2.107.0)
- Danger: 5.7.1 (https://github.com/danger/danger/releases/tag/v5.7.1)
- travis-ci Xcode image: xcode10.1 (https://blog.travis-ci.com/2018-11-01-xcode-10-1-is-now-available)